### PR TITLE
Hotfix/test 16 06 23

### DIFF
--- a/view/case_form.py
+++ b/view/case_form.py
@@ -5,10 +5,12 @@
 # Copyright (c) 2023 FIT-Project
 # SPDX-License-Identifier: GPL-3.0-only
 # -----
-######  
+######
+import string
 
 from PyQt6 import QtCore, QtGui, QtWidgets
-
+from PyQt6.QtCore import QRegularExpression
+from PyQt6.QtGui import QRegularExpressionValidator
 
 from controller.case import Case as CaseController
 from controller.configurations.tabs.general.typesproceedings import TypesProceedings as TypesProceedingsController
@@ -50,6 +52,8 @@ class CaseForm(QtWidgets.QWidget):
         self.name_label.setObjectName("name_label")
         self.case_form_layout.setWidget(0, QtWidgets.QFormLayout.ItemRole.LabelRole, self.name_label)
         self.name = QtWidgets.QComboBox(self)
+        self.name.editTextChanged.connect(self.__validate_input)
+
         font = QtGui.QFont()
         font.setPointSize(10)
         self.name.setFont(font)
@@ -119,7 +123,14 @@ class CaseForm(QtWidgets.QWidget):
 
         self.retranslateUi()
 
+    def __validate_input(self, text):
+        valid_text = self.__remove_chars(text)
+        self.name.setEditText(valid_text)
 
+    def __remove_chars(self, text):
+        valid_characters = string.ascii_letters + string.digits + "_-"
+        valid_text = ''.join(c for c in text if c.lower() in valid_characters)
+        return valid_text
     def retranslateUi(self):
 
         self.setWindowTitle(TITLE)

--- a/view/case_form.py
+++ b/view/case_form.py
@@ -9,8 +9,6 @@
 import string
 
 from PyQt6 import QtCore, QtGui, QtWidgets
-from PyQt6.QtCore import QRegularExpression
-from PyQt6.QtGui import QRegularExpressionValidator
 
 from controller.case import Case as CaseController
 from controller.configurations.tabs.general.typesproceedings import TypesProceedings as TypesProceedingsController

--- a/view/instagram.py
+++ b/view/instagram.py
@@ -99,7 +99,9 @@ class Instagram(QtWidgets.QMainWindow):
 
 
         self.setObjectName("mainWindow")
-        self.resize(530, 480)
+        self.width = 530
+        self.height = 480
+        self.setFixedSize(self.width, self.height)
         self.centralwidget = QtWidgets.QWidget(self)
         self.centralwidget.setStyleSheet("QWidget {background-color: rgb(255, 255, 255);}")
         self.centralwidget.setObjectName("centralwidget")
@@ -358,7 +360,9 @@ class Instagram(QtWidgets.QMainWindow):
         self.username = self.input_username.text()
         self.password = self.input_password.text()
         self.profile =  self.input_profile.text()
-
+        center_x = self.x() + self.width / 2
+        center_y = self.y() + self.height / 2
+        self.spinner.set_position(center_x, center_y)
         self.spinner.start()
         self.setEnabled(False)
 

--- a/view/instagram.py
+++ b/view/instagram.py
@@ -258,9 +258,9 @@ class Instagram(QtWidgets.QMainWindow):
         self.checkbox_saved_post.setFont(font)
         self.checkbox_saved_post.setObjectName("checkbox_saved_post")
 
-       
-        self.scrape_button = QtWidgets.QPushButton(self.centralwidget)
-        self.scrape_button.setGeometry(QtCore.QRect(410, 390, 70, 25))
+
+        self.scrape_button = QtWidgets.QPushButton(self)
+        self.scrape_button.setGeometry(QtCore.QRect(410, 410, 70, 25))
         self.scrape_button.setObjectName("scrapeButton")
         self.scrape_button.setFont(font)
         self.scrape_button.clicked.connect(self.__scrape)

--- a/view/mail.py
+++ b/view/mail.py
@@ -449,7 +449,9 @@ class Mail(QtWidgets.QMainWindow):
 
         if self.configuration_group_box.isEnabled():
             self.configuration_group_box.setEnabled(False)
-
+        center_x = self.x() + self.width / 2
+        center_y = self.y() + self.height / 2
+        self.spinner.set_position(center_x,center_y)
         self.spinner.start()
         self.setEnabled(False)
 

--- a/view/mail.py
+++ b/view/mail.py
@@ -335,16 +335,16 @@ class Mail(QtWidgets.QMainWindow):
         self.label_to_date.setObjectName("label_to_date")
 
         # LOGIN BUTTON
-        self.search_button = QtWidgets.QPushButton(self.centralwidget)
-        self.search_button.setGeometry(QRect(405, 505, 75, 25))
+        self.search_button = QtWidgets.QPushButton(self)
+        self.search_button.setGeometry(QRect(405, 525, 75, 25))
         self.search_button.clicked.connect(self.__search)
         self.search_button.setFont(font)
         self.search_button.setObjectName("search_action")
         self.search_button.setEnabled(False)
 
         # SCRAPE BUTTON
-        self.download_button = QtWidgets.QPushButton(self.centralwidget)
-        self.download_button.setGeometry(QRect(875, 505, 75, 25))
+        self.download_button = QtWidgets.QPushButton(self)
+        self.download_button.setGeometry(QRect(875, 525, 75, 25))
         self.download_button.clicked.connect(self.__download)
         self.download_button.setFont(font)
         self.download_button.setObjectName("StartAction")

--- a/view/spinner.py
+++ b/view/spinner.py
@@ -24,13 +24,20 @@ class Spinner(QDialog):
     def initUI(self):
         self.setWindowFlag(PyQt6.QtCore.Qt.WindowType.FramelessWindowHint)
         self.setAttribute(PyQt6.QtCore.Qt.WidgetAttribute.WA_TranslucentBackground)
-        self.resize(200, 200)
+        self.width = 200
+        self.height = 200
+        self.resize(self.width, self.height)
         self.centralwidget = QWidget(self)       
         self.label = QLabel(self.centralwidget)
-        self.label.setGeometry(QRect(0, 0, 200, 200))
+        self.label.setGeometry(QRect(0, 0, self.width, self.height))
         self.movie = QMovie(os.path.join('assets/images/', 'loader.gif'))
         self.label.setMovie(self.movie)
         self.setModal(True)
+
+    def set_position(self, x,y):
+        widget_x = x - self.width / 2
+        widget_y = y - self.height / 2
+        self.move(widget_x,widget_y)
 
     def start(self):
         self.movie.start()

--- a/view/verify_pdf_timestamp.py
+++ b/view/verify_pdf_timestamp.py
@@ -142,8 +142,8 @@ class VerifyPDFTimestamp(QtWidgets.QMainWindow):
         self.label_crt.setObjectName("label_crt")
 
         # VERIFICATION BUTTON
-        self.verification_button = QtWidgets.QPushButton(self.centralwidget)
-        self.verification_button.setGeometry(QtCore.QRect(300, 170, 75, 30))
+        self.verification_button = QtWidgets.QPushButton(self)
+        self.verification_button.setGeometry(QtCore.QRect(300, 190, 75, 30))
         self.verification_button.clicked.connect(self.verify)
         self.verification_button.setFont(font)
         self.verification_button.setObjectName("StartAction")

--- a/view/verify_pec.py
+++ b/view/verify_pec.py
@@ -66,7 +66,7 @@ class VerifyPec(QtWidgets.QMainWindow):
 
         self.eml_group_box = QtWidgets.QGroupBox(self.centralwidget)
         self.eml_group_box.setEnabled(True)
-        self.eml_group_box.setGeometry(QtCore.QRect(50, 20, 500, 180))
+        self.eml_group_box.setGeometry(QtCore.QRect(50, 20, 500, 160))
         self.eml_group_box.setObjectName("eml_group_box")
 
         # EML
@@ -85,7 +85,7 @@ class VerifyPec(QtWidgets.QMainWindow):
         self.label_eml.setObjectName("label_eml")
 
         # VERIFICATION BUTTON
-        self.verification_button = QtWidgets.QPushButton(self.centralwidget)
+        self.verification_button = QtWidgets.QPushButton(self)
         self.verification_button.setGeometry(QtCore.QRect(450, 140, 75, 30))
         self.verification_button.clicked.connect(self.__verify)
         self.verification_button.setObjectName("StartAction")


### PR DESCRIPTION
fixed:

- fare in modo che in cliente/caso ci siano solo caratteri consentiti come nome di cartella
- se sposto il tool, lo spinner rimane nella posizione di partenza e non segue il tool
- disabilitare tasto di scraping e-mail se i campi non sono compilati