### PR TITLE
added tsa certificate to the pec

### DIFF
--- a/controller/pec.py
+++ b/controller/pec.py
@@ -51,6 +51,7 @@ class Pec():
 
         pdf = os.path.join(self.acquisition_directory, 'acquisition_report.pdf')
         tsr = os.path.join(self.acquisition_directory, 'timestamp.tsr')
+        crt = os.path.join(self.acquisition_directory, 'tsa.crt')
 
         # Attach PDF Report
         with open(pdf, "rb") as f:
@@ -62,6 +63,12 @@ class Pec():
         with open(tsr, "rb") as f:
             attach_tsr = MIMEApplication(f.read(), _subtype="tsr")
             attach_tsr.add_header('content-disposition', 'attachment', filename="timestamp.tsr")
+            msg.attach(attach_tsr)
+
+        # Attach CRT file
+        with open(crt, "rb") as f:
+            attach_tsr = MIMEApplication(f.read(), _subtype="crt")
+            attach_tsr.add_header('content-disposition', 'attachment', filename="tsa.crt")
             msg.attach(attach_tsr)
 
         try:

--- a/controller/pec.py
+++ b/controller/pec.py
@@ -67,9 +67,9 @@ class Pec():
 
         # Attach CRT file
         with open(crt, "rb") as f:
-            attach_tsr = MIMEApplication(f.read(), _subtype="crt")
-            attach_tsr.add_header('content-disposition', 'attachment', filename="tsa.crt")
-            msg.attach(attach_tsr)
+            attach_crt = MIMEApplication(f.read(), _subtype="crt")
+            attach_crt.add_header('content-disposition', 'attachment', filename="tsa.crt")
+            msg.attach(attach_crt)
 
         try:
             server = smtplib.SMTP_SSL(self.smtp_server, self.smtp_port)


### PR DESCRIPTION
Use case: we want to verify the validity of a report attached to a pec. In the attachments we have the actual report (.pdf) and its timestamp (.tsr), but not the TSA certificate (.crt) and we cannot verify the report without it. Attaching the certificate will solve this problem.