### PR TITLE
Fixes float errors when run using poetry run

### DIFF
--- a/view/acquisition/base.py
+++ b/view/acquisition/base.py
@@ -105,12 +105,12 @@ class Base(QObject):
 
     def set_completed_progress_bar(self):
         if self.__progress_bar:
-            self.increment = 100 - self.__progress_bar.value()
+            self.increment = int(100 - self.__progress_bar.value())
             self.upadate_progress_bar()
 
     def upadate_progress_bar(self):
         if self.__progress_bar:
-            self.__progress_bar.setValue(self.__progress_bar.value() + self.increment)
+            self.__progress_bar.setValue(int(self.__progress_bar.value() + self.increment))
 
     def set_message_on_the_statusbar(self, message):
         if self.__status_bar:

--- a/view/spinner.py
+++ b/view/spinner.py
@@ -34,8 +34,8 @@ class Spinner(QDialog):
         self.setModal(True)
 
     def set_position(self, x, y):
-        widget_x = x - self.width / 2
-        widget_y = y - self.height / 2
+        widget_x = int(x - self.width / 2)
+        widget_y = int(y - self.height / 2)
         self.move(widget_x, widget_y)
 
     def start(self):

--- a/view/web/navigationtoolbar.py
+++ b/view/web/navigationtoolbar.py
@@ -73,7 +73,7 @@ class NavigationToolBar(QtWidgets.QToolBar):
 
         # Set urlbar width seventy percent of primary screen
         self.urlbar.setMaximumWidth(
-            QtGui.QGuiApplication.primaryScreen().geometry().width() * 0.7
+            int(QtGui.QGuiApplication.primaryScreen().geometry().width() * 0.7)
         )
         self.addWidget(self.urlbar)
 

--- a/view/web/web.py
+++ b/view/web/web.py
@@ -560,7 +560,7 @@ class Web(QtWidgets.QMainWindow):
                     loop.exec()
                     self.tabs.currentWidget().grab().save(filename)
 
-                progress += increment
+                progress += int(increment)
                 self.progress_bar.setValue(progress)
 
                 images.append(filename)
@@ -600,7 +600,7 @@ class Web(QtWidgets.QMainWindow):
                 self.__are_internal_tasks_completed()
 
             else:
-                self.progress_bar.setValue(100 - progress)
+                self.progress_bar.setValue(int(100 - progress))
                 self.__enable_all()
                 self.progress_bar.setHidden(True)
 

--- a/view/wizard.py
+++ b/view/wizard.py
@@ -37,14 +37,14 @@ class CaseInfoPage(QtWidgets.QWizardPage):
         self.form = CaseFormView(self.case_form_widget)
         self.form.setGeometry(QtCore.QRect(0, 0, 400, 250))
 
-        x = (
+        x = int((
             (self.case_form_widget.frameGeometry().width() / 2)
             - (self.form.frameGeometry().width() / 2)
             - 20
-        )
-        y = (self.case_form_widget.frameGeometry().height() / 2) - (
+        ))
+        y = int((self.case_form_widget.frameGeometry().height() / 2) - (
             self.form.frameGeometry().height() / 2
-        )
+        ))
         self.form.move(x, y)
 
         self.configuration_button = QtWidgets.QPushButton(self)


### PR DESCRIPTION
When using the `poetry run python fit.py` command, the following error would occur frequently:
```bash
TypeError: arguments did not match any overloaded call:
  move(self, a0: QPoint): argument 1 has unexpected type 'float'
  move(self, ax: int, ay: int): argument 1 has unexpected type 'float'
```
This seems to only affect Python 3.10 at this time, but the changes in this PR do not affect any other Python versions.