### PR TITLE
fix: correct version format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fit"
-version = "v.2.0.1"
+version = "2.0.1"
 description = "FIT is a Python3 application for forensic acquisition of contents like web pages, emails, social media, etc. directly from the internet."
 authors = ["Fit Project <info@fit-project.org>"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
The version number was incorrectly prefixed with v.
This has been fixed to follow the correct semantic versioning format as 2.0.1.

File: pyproject.toml